### PR TITLE
param size to 'IO.read' solve problem firefox PDF

### DIFF
--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -211,7 +211,7 @@ async function readProtocolStream(
   if (path) file = await openAsync(path, 'w');
   const bufs = [];
   while (!eof) {
-    const response = await client.send('IO.read', { handle });
+    const response = await client.send('IO.read', { handle: handle, size: 102400 });
     eof = response.eof;
     const buf = Buffer.from(
       response.data,


### PR DESCRIPTION
problem  related to the size of the generated PDF with firefox

doc for IO.read: https://chromedevtools.github.io/devtools-protocol/tot/IO/